### PR TITLE
Topic type completion & Service completion

### DIFF
--- a/completions/ros2.fish
+++ b/completions/ros2.fish
@@ -648,8 +648,19 @@ for i in (seq (count $ros2_service_commands))
     $C -n "__fish_seen_subcommand_from service; and not __fish_seen_subcommand_from $ros2_service_commands" -a $command -d $description
 end
 
-$C -n "__fish_seen_subcommand_with_subsubcommand service call" -a "(__fish_ros2_print_services)"
+$C -n "__fish_seen_subcommand_with_subsubcommand service call; and not __fish_ros2_cmd_in_array ($__fish_ros2 service list)" -a "(__fish_ros2_print_services)"
 $C -n "__fish_seen_subcommand_with_subsubcommand service info" -a "(__fish_ros2_print_services)"
+
+# Get the service type, assuming the last cmdline token is the service name
+function __fish_ros2_get_service_type
+    set -l cmd (commandline -poc)
+    set -l service $cmd[-1]
+
+    echo ($__fish_ros2 service type $service)
+    return 0
+end
+
+$C -n "__fish_seen_subcommand_with_subsubcommand service call; and __fish_seen_nth_arg_from -1 ($__fish_ros2 service list)" -a "(__fish_ros2_get_service_type)"
 
 # ros2 topic --------------------------------------------------------------------------------------
 # ros2 topic --help

--- a/completions/ros2.fish
+++ b/completions/ros2.fish
@@ -3,6 +3,7 @@ set -l C complete --command ros2
 set -g __fish_ros2 /opt/ros/$ROS_DISTRO/bin/ros2
 set -g ros2_exe (command --search ros2)
 
+# Check if the command line's second and third arguments are the same as the given subcommand and subsubcommand
 function __fish_seen_subcommand_with_subsubcommand --argument-names subcommand subsubcommand
     set -l cmd (commandline -poc)
     set -e cmd[1]
@@ -18,6 +19,7 @@ function __fish_seen_subcommand_with_subsubcommand --argument-names subcommand s
     return 0
 end
 
+# Check if command line's second argument is the same as the given subcommand and has more than 2 arguments
 function __fish_seen_subcommand_with_argument --argument-names subcommand
     set -l cmd (commandline -poc)
     set -e cmd[1]
@@ -73,7 +75,7 @@ set -g __fish_ros2_all_subcommands \
     $__fish_ros2_topic_subcommands \
     $__fish_ros2_wtf_subcommands
 
-
+# Check if any of the command line tokens is contained in the given array
 function __fish_ros2_cmd_in_array
     for i in (commandline -pco)
         # -- is used to provide no options for contains
@@ -195,6 +197,7 @@ $C -s h -l help -d "show this help message and exit"
 set -l ros2_commands action bag component daemon doctor interface launch lifecycle multicast node param pkg run security service topic wtf
 set -l ros2_command_extensions control
 
+# If we haven't typed any of the first-level commands, suggest them
 $C -n "not __fish_seen_subcommand_from $ros2_commands $ros2_command_extensions" -a action -d "action related sub-commands"
 $C -n "not __fish_seen_subcommand_from $ros2_commands $ros2_command_extensions" -a bag -d "rosbag related sub-commands"
 $C -n "not __fish_seen_subcommand_from $ros2_commands $ros2_command_extensions" -a component -d "component related sub-commands"

--- a/completions/ros2.fish
+++ b/completions/ros2.fish
@@ -54,7 +54,7 @@ set -g __fish_ros2_service_subcommands call list type
 set -g __fish_ros2_topic_subcommands echo hz info list pub type
 set -g __fish_ros2_wtf_subcommands
 
-set -g __fish_ros2_subcommands \
+set -g __fish_ros2_all_subcommands \
     $__fish_ros2_action_subcommands \
     $__fish_ros2_bag_subcommands \
     $__fish_ros2_component_subcommands \

--- a/completions/ros2.fish
+++ b/completions/ros2.fish
@@ -88,10 +88,6 @@ function __fish_ros2_cmd_in_array
     return 1
 end
 
-function __fish_ros2_no_subcommand
-    not __fish_ros2_cmd_in_array $__fish_ros2_all_commands $__fish_ros2_subcommands
-end
-
 function __fish_ros2_print_packages
     $__fish_ros2 pkg list
 end
@@ -156,10 +152,6 @@ function __fish_ros2_print_topics
         printf '%s\t%s\n' $topic (string sub --start 2 --end -1 $type) # remove "[" and "]"
     end
 end
-
-# function __fish_ros2_print_services
-#     $__fish_ros2 service list
-# end
 
 # usage: ros2 [-h] Call `ros2 <command> -h` for more detailed usage. ...
 #

--- a/completions/ros2.fish
+++ b/completions/ros2.fish
@@ -632,6 +632,9 @@ for i in (seq (count $ros2_service_commands))
     $C -n "__fish_seen_subcommand_from service; and not __fish_seen_subcommand_from $ros2_service_commands" -a $command -d $description
 end
 
+$C -n "__fish_seen_subcommand_with_subsubcommand service call" -a "(__fish_ros2_print_services)"
+$C -n "__fish_seen_subcommand_with_subsubcommand service info" -a "(__fish_ros2_print_services)"
+
 # ros2 topic --------------------------------------------------------------------------------------
 # ros2 topic --help
 # usage: ros2 topic [-h] [--include-hidden-topics] Call `ros2 topic <command> -h` for more detailed usage. ...

--- a/completions/ros2.fish
+++ b/completions/ros2.fish
@@ -47,21 +47,6 @@ function __fish_seen_nth_arg_from --argument-names n
     return 1
 end
 
-# Check if anything is being called with the any of the arguments/tokens contained in the given array. Tis can be helpful, e.g.:
-# - to check `ros2 topic echo` is being called with a topic name already given
-# - with n=-2 to check whether a topic name has been given plus with n=-1 to check whether a message type has been given
-function __fish_seen_any_arg_from
-    set -l cmd (commandline -poc)
-
-    for arg in $cmd
-        if contains -- $arg $argv
-            return 0
-        end
-    end
-
-    return 1
-end
-
 
 # Print all files recursively in the current directory with the given extension
 function __fish_print_files_in_subdirectories_with_extension --argument-names extension
@@ -709,7 +694,7 @@ for i in (seq (count $ros2_topic_commands))
 end
 
 $C -n "__fish_seen_subcommand_with_subsubcommand topic echo" -a "(__fish_ros2_print_topics)"
-$C -n "__fish_seen_subcommand_with_subsubcommand topic pub; and not __fish_seen_any_arg_from (ros2 topic list)" -a "(__fish_ros2_print_topics)"
+$C -n "__fish_seen_subcommand_with_subsubcommand topic pub; and not __fish_ros2_cmd_in_array (ros2 topic list)" -a "(__fish_ros2_print_topics)"
 $C -n "__fish_seen_subcommand_with_subsubcommand topic hz" -a "(__fish_ros2_print_topics)"
 $C -n "__fish_seen_subcommand_with_subsubcommand topic bw" -a "(__fish_ros2_print_topics)"
 $C -n "__fish_seen_subcommand_with_subsubcommand topic info" -a "(__fish_ros2_print_topics)"

--- a/completions/ros2.fish
+++ b/completions/ros2.fish
@@ -169,6 +169,20 @@ function __fish_ros2_print_topics
     end
 end
 
+function __fish_ros2_print_available_lifecycle_transisions --argument-names node
+    set -l lines ($__fish_ros2 lifecycle list $node 2>/dev/null)
+    for line in $lines
+
+        set -l first_char (string sub --length 1 -- $line)
+        if test $first_char != -
+            continue
+        end
+
+        set -l tokens (string split " " -- $line)
+        printf '%s\t%s\n' $tokens[2] (string sub --start 2 --end -1 $tokens[3])
+    end
+end
+
 # usage: ros2 [-h] Call `ros2 <command> -h` for more detailed usage. ...
 #
 # ros2 is an extensible command-line tool for ROS 2.
@@ -458,6 +472,12 @@ for i in (seq (count $ros2_lifecycle_commands))
     set -l description $ros2_lifecycle_command_descriptions[$i]
     $C -n "__fish_seen_subcommand_from lifecycle; and not __fish_seen_subcommand_from $ros2_lifecycle_commands" -a $command -d $description
 end
+
+$C -n "__fish_seen_subcommand_with_subsubcommand lifecycle set; and not __fish_ros2_cmd_in_array ($__fish_ros2 lifecycle nodes)" -a "($__fish_ros2 lifecycle nodes)"
+$C -n "__fish_seen_subcommand_with_subsubcommand lifecycle get" -a "($__fish_ros2 lifecycle nodes)"
+$C -n "__fish_seen_subcommand_with_subsubcommand lifecycle list" -a "($__fish_ros2 lifecycle nodes)"
+
+$C -n "__fish_seen_subcommand_with_subsubcommand lifecycle set; and __fish_seen_nth_arg_from -1 ($__fish_ros2 lifecycle nodes)" -a "(__fish_ros2_print_available_lifecycle_transisions (commandline -opc)[-1])"
 
 # ros2 multicast ----------------------------------------------------------------------------------
 # ros2 multicast --help

--- a/completions/ros2.fish
+++ b/completions/ros2.fish
@@ -705,21 +705,22 @@ for i in (seq (count $ros2_topic_commands))
 end
 
 $C -n "__fish_seen_subcommand_with_subsubcommand topic echo" -a "(__fish_ros2_print_topics)"
-$C -n "__fish_seen_subcommand_with_subsubcommand topic pub; and not __fish_ros2_cmd_in_array (ros2 topic list)" -a "(__fish_ros2_print_topics)"
+$C -n "__fish_seen_subcommand_with_subsubcommand topic pub; and not __fish_ros2_cmd_in_array ($__fish_ros2 topic list)" -a "(__fish_ros2_print_topics)"
 $C -n "__fish_seen_subcommand_with_subsubcommand topic hz" -a "(__fish_ros2_print_topics)"
 $C -n "__fish_seen_subcommand_with_subsubcommand topic bw" -a "(__fish_ros2_print_topics)"
 $C -n "__fish_seen_subcommand_with_subsubcommand topic info" -a "(__fish_ros2_print_topics)"
 $C -n "__fish_seen_subcommand_with_subsubcommand topic type" -a "(__fish_ros2_print_topics)"
 
-# Insert the topic type, assuming the last cmdline token is the topic
+# Get the topic type, assuming the last cmdline token is the topic name
 function __fish_ros2_get_topic_type
     set -l cmd (commandline -poc)
     set -l topic $cmd[-1]
 
-    echo (ros2 topic type $topic)
+    echo ($__fish_ros2 topic type $topic)
     return 0
 end
-$C -n "__fish_seen_subcommand_with_subsubcommand topic pub; and __fish_seen_nth_arg_from -1 (ros2 topic list)" -a "(__fish_ros2_get_topic_type)"
+
+$C -n "__fish_seen_subcommand_with_subsubcommand topic pub; and __fish_seen_nth_arg_from -1 ($__fish_ros2 topic list)" -a "(__fish_ros2_get_topic_type)"
 
 
 

--- a/conf.d/ros2.fish
+++ b/conf.d/ros2.fish
@@ -2,7 +2,7 @@ status is-interactive; or return 0
 
 begin
     echo $version | read --delimiter . major minor patch
-    if not test $major -ge 3 -a $minor -ge 6
+    if not test $major -ge 4; or test $major = 3 -a $minor -ge 6
         set -l reset (set_color normal)
         printf "[%sros2.fish%s] %serror%s: minimum required %sfish%s version is %s3.6.0%s, but you have %s%s%s\n" (set_color blue) $reset (set_color red) $reset (set_color $fish_color_command) $reset (set_color green) $reset (set_color red) $version $reset
         return 0


### PR DESCRIPTION
Regarding https://github.com/kpbaks/ros2.fish/issues/9
Basically see commit titles. Let me know if you disagree with adding comments etc. or if this should be split into _add service name completion_ and _add topic type completion_.

Service name completion (line 665 to 666) is straightforward and analog to topic name completion, which existed beforehand.

Completing the topic type was a bit trickier with regards to getting the condition right. I'm still not fully happy as command line options that take an argument (e.g. `--rate 10`) make up 2 tokens, one of which isn't starting with a `-` (I remove any tokens starting with a dash) and would invalidate the condition. Thinking about it, it could be better to simply check, whether the last token of the command line is a topic from`(ros2 topic list)`.  Maybe I will do that but not today. Let me know if you have any suggestions, though.

It works as it is but could be a bit more robust. Once it is, something similar could be done for services. And using `ros2 interface proto <interface type>`, adding completion for filling out the message/service request could probably be somewhat easy.